### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,18 +1,25 @@
-# https://editorconfig.org
+# .editorconfig
+# See https://editorconfig.org for documentation.
+# This configuration ensures consistent coding styles across multiple editors and IDEs.
+
 root = true
 
+# The following rules apply to all files (unless overridden in specific sections below).
 [*]
-indent_style = space
-end_of_line = lf
 charset = utf-8
+end_of_line = lf
+indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# Java / Scala / Groovy / Kotlin files: standard 4-space indentation.
 [*.{java,scala,groovy,kt,kts}]
 indent_size = 4
 
+# Gradle files often use 2-space indentation for readability.
 [*.gradle]
 indent_size = 2
 
+# Markdown files: typically don't remove trailing whitespace (it can break formatting).
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Explanation of Improvements
Explicit Comments

Added descriptive comments explaining the purpose of each section, making it friendlier for contributors who might not be as familiar with EditorConfig. Root Specification

Kept root = true to ensure this is the topmost .editorconfig file, so any further .editorconfig files in subdirectories won't override these rules. File Grouping

Maintained separate blocks [*.{java,scala,groovy,kt,kts}] and [*.gradle], so users can quickly adapt or add more extensions (like .c, .cpp, or .cs if they want) without confusion. Minor Indentation Clarifications

Provided rationale for 2-space indentation in .gradle files, as that's quite common in Gradle build scripts. Markdown Trimming

Retained the trim_trailing_whitespace = false for *.md to avoid rendering issues in certain documentation formats. This refined .editorconfig ensures consistent styles across multiple languages and clarifies the reasons behind each setting, making it both practical and maintainable for a team.